### PR TITLE
Add async startup update check with welcome notification

### DIFF
--- a/docs/feature_doc/issue_26_update_check_plan.md
+++ b/docs/feature_doc/issue_26_update_check_plan.md
@@ -1,0 +1,230 @@
+# Issue #26 Implementation Plan: Startup New Version Notification
+
+## Issue Summary
+Add a non-blocking startup enhancement that checks whether a newer `wtf_cli` release is available and, when true, shows a notification under the welcome shortcuts section. The notice should include:
+
+- current running version
+- latest available version
+- link to Releases page
+- one-line upgrade/install command from README
+
+The check must **not impact bootstrap/startup responsiveness**.
+
+---
+
+## Goals and Non-Goals
+
+### Goals
+1. Run release check asynchronously during startup (no UI thread blocking).
+2. Show update notification only when a newer version exists.
+3. Keep startup robust when offline / rate-limited / API errors occur.
+4. Provide config + caching controls to reduce repeated network calls.
+5. Add test coverage for compare logic, model integration, and welcome rendering.
+
+### Non-Goals
+- Auto-updating binaries in-app.
+- Mandatory update prompts.
+- Introducing any startup hard-failure path due to update check errors.
+
+---
+
+## Proposed Design
+
+### 1) New package: `pkg/updatecheck`
+Create a focused service package for release lookup and version comparison.
+
+**Proposed API**
+
+```go
+type Result struct {
+    CurrentVersion  string
+    LatestVersion   string
+    ReleaseURL      string
+    UpgradeCommand  string
+    UpdateAvailable bool
+}
+
+func CheckLatest(ctx context.Context, currentVersion string) (Result, error)
+```
+
+**Behavior**
+- Query GitHub latest release endpoint:
+  - `https://api.github.com/repos/pakru/wtf_cli/releases/latest`
+- Parse `tag_name` and normalize versions (`v0.3.0` vs `0.3.0`).
+- Compare semver-like values; if parse fails, return no-update + error.
+- Skip check for local/dev builds (`version.Version == "dev"` or empty).
+- Always include canonical links/command in result:
+  - Releases: `https://github.com/pakru/wtf_cli/releases`
+  - Upgrade: `curl -fsSL https://raw.githubusercontent.com/pakru/wtf_cli/main/install.sh | bash`
+
+**Failure policy**
+- Never panic.
+- On check failures, only write a warning log and continue silently (no user-facing error state).
+
+---
+
+### 2) Bubble Tea integration in `pkg/ui/model.go`
+Use the existing async command/message architecture.
+
+**Additions**
+- New message type:
+
+```go
+type updateCheckMsg struct {
+    Result updatecheck.Result
+    Err    error
+}
+```
+
+- New command:
+
+```go
+func fetchUpdateCheckCmd() tea.Cmd
+```
+
+This command should:
+- execute with short timeout (e.g., 2–5s)
+- call `updatecheck.CheckLatest(...)`
+- return `updateCheckMsg`
+
+**Startup wiring**
+- Add to `Model.Init()` via `tea.Batch(...)` alongside existing startup commands.
+- Ensure async network call never blocks PTY/UI startup.
+
+**State handling**
+- Add model field(s) for update notice payload and whether applied.
+- On `updateCheckMsg` with `UpdateAvailable=true`, inject/update welcome notice section.
+- On no-update/error: no visible notification; log at debug/info.
+
+---
+
+### 3) Welcome component extension
+Current `WelcomeMessage()` is static. Extend it to optionally include update content.
+
+**Option A (preferred):**
+- Keep current API for compatibility:
+  - `WelcomeMessage() string`
+- Add:
+  - `WelcomeMessageWithUpdate(info *UpdateNotice) string`
+
+Where `UpdateNotice` contains:
+- current version
+- latest version
+- release URL
+- upgrade command
+
+**Rendering requirements**
+- Place section **under shortcut hints**.
+- Preserve box layout/width.
+- Truncate long lines safely with existing width utilities.
+- Keep style consistent using existing `pkg/ui/styles` tokens.
+
+---
+
+### 4) Config + cache controls
+To avoid unnecessary startup calls and allow opt-out, extend config.
+
+**New config block**
+
+```json
+"update_check": {
+  "enabled": true,
+  "interval_hours": 24
+}
+```
+
+**Implementation changes (`pkg/config/config.go`)**
+- Add `UpdateCheckConfig` struct.
+- Add field to `Config`.
+- Add defaults in `Default()`.
+- Extend `configPresence` + `applyDefaults()`.
+- Validate `interval_hours > 0` (or clamp to default).
+
+**Cache strategy**
+- Store a lightweight cache file in `~/.wtf_cli/` with:
+  - last check timestamp
+  - last known latest tag
+- Skip network call when:
+  - disabled in config
+  - interval not elapsed
+  - running dev build
+
+---
+
+### 5) Logging and observability
+Add structured logs for diagnosability without noise.
+
+Suggested events:
+- `update_check_start`
+- `update_check_skipped` (`reason`: disabled/dev/interval)
+- `update_check_success` (`current`, `latest`, `update_available`)
+- `update_check_error` (`error`)
+
+---
+
+## Test Plan
+
+### Unit tests (`pkg/updatecheck`)
+1. `tag_name` parsing + normalization with/without `v` prefix.
+2. Version compare cases:
+   - current < latest
+   - current == latest
+   - current > latest
+   - invalid versions
+3. HTTP failures, malformed payload, timeout handling.
+4. Dev-build skip behavior.
+
+### UI component tests (`pkg/ui/components/welcome`)
+1. Update section appears when notice exists.
+2. Update section absent when notice is nil.
+3. Strings included:
+   - current version
+   - latest version
+   - releases URL
+   - upgrade curl command
+
+### Model tests (`pkg/ui/model_test.go`)
+1. `updateCheckMsg` success with update toggles notice state.
+2. No-update and error paths do not break normal rendering.
+3. Startup command batching still initializes PTY listener + directory ticks.
+
+### Golden tests
+- If welcome rendering changes visible output, regenerate/update corresponding golden files.
+
+---
+
+## Rollout Strategy
+
+1. Implement updatecheck package and unit tests.
+2. Integrate async command/message in model.
+3. Extend welcome component and tests.
+4. Add config + cache controls.
+5. Run `make check` and update golden files if necessary.
+6. Open PR with screenshots optional (not required unless additional visual TUI changes beyond welcome text formatting need explicit review).
+
+---
+
+## Risks and Mitigations
+
+1. **Startup slowdown**
+   - Mitigation: async command + short timeout + interval cache.
+2. **GitHub API rate limits/network errors**
+   - Mitigation: silent fallback, log only, no user disruption.
+3. **Version parsing edge cases**
+   - Mitigation: strict normalization tests + conservative fallback.
+4. **Welcome layout overflow**
+   - Mitigation: truncation/wrapping tests at fixed box width.
+
+---
+
+## Acceptance Criteria
+
+1. On startup, when a newer release exists, the welcome section shows:
+   - current version
+   - latest version
+   - releases URL
+   - install/upgrade curl command
+2. On no-update/error/offline, no crash and no startup delay regressions.
+3. Check is configurable and can be disabled.
+4. Repeated launches within interval do not hit network.
+5. Test suite and golden outputs pass via project checks.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,15 +11,16 @@ import (
 
 // Config represents the application configuration
 type Config struct {
-	LLMProvider   string           `json:"llm_provider"`
-	OpenRouter    OpenRouterConfig `json:"openrouter"`
-	Providers     ProvidersConfig  `json:"providers"`
-	BufferSize    int              `json:"buffer_size"`
-	ContextWindow int              `json:"context_window"`
-	StatusBar     StatusBarConfig  `json:"status_bar"`
-	LogFile       string           `json:"log_file"`
-	LogFormat     string           `json:"log_format"`
-	LogLevel      string           `json:"log_level"`
+	LLMProvider   string            `json:"llm_provider"`
+	OpenRouter    OpenRouterConfig  `json:"openrouter"`
+	Providers     ProvidersConfig   `json:"providers"`
+	BufferSize    int               `json:"buffer_size"`
+	ContextWindow int               `json:"context_window"`
+	StatusBar     StatusBarConfig   `json:"status_bar"`
+	UpdateCheck   UpdateCheckConfig `json:"update_check"`
+	LogFile       string            `json:"log_file"`
+	LogFormat     string            `json:"log_format"`
+	LogLevel      string            `json:"log_level"`
 }
 
 // ProvidersConfig holds configuration for all LLM providers.
@@ -85,6 +86,12 @@ type StatusBarConfig struct {
 	Colors   string `json:"colors"`   // "auto"
 }
 
+// UpdateCheckConfig holds startup update-check configuration
+type UpdateCheckConfig struct {
+	Enabled       bool `json:"enabled"`
+	IntervalHours int  `json:"interval_hours"`
+}
+
 // Default returns a configuration with default values
 func Default() Config {
 	return Config{
@@ -113,6 +120,10 @@ func Default() Config {
 		StatusBar: StatusBarConfig{
 			Position: "bottom",
 			Colors:   "auto",
+		},
+		UpdateCheck: UpdateCheckConfig{
+			Enabled:       true,
+			IntervalHours: 24,
 		},
 		LogFile:   defaultLogFilePath(),
 		LogFormat: "json",
@@ -221,6 +232,10 @@ func (c Config) Validate() error {
 		return fmt.Errorf("context_window must be positive, got: %d", c.ContextWindow)
 	}
 
+	if c.UpdateCheck.IntervalHours <= 0 {
+		return fmt.Errorf("update_check.interval_hours must be positive, got: %d", c.UpdateCheck.IntervalHours)
+	}
+
 	if strings.TrimSpace(c.LogLevel) != "" {
 		switch strings.ToLower(strings.TrimSpace(c.LogLevel)) {
 		case "trace", "debug", "info", "warn", "warning", "error":
@@ -322,6 +337,10 @@ type configPresence struct {
 		Position *string `json:"position"`
 		Colors   *string `json:"colors"`
 	} `json:"status_bar"`
+	UpdateCheck *struct {
+		Enabled       *bool `json:"enabled"`
+		IntervalHours *int  `json:"interval_hours"`
+	} `json:"update_check"`
 	LogFile   *string `json:"log_file"`
 	LogFormat *string `json:"log_format"`
 	LogLevel  *string `json:"log_level"`
@@ -403,6 +422,17 @@ func applyDefaults(cfg Config, data []byte) Config {
 		}
 		if presence.StatusBar.Colors == nil || strings.TrimSpace(cfg.StatusBar.Colors) == "" {
 			cfg.StatusBar.Colors = defaults.StatusBar.Colors
+		}
+	}
+
+	if presence.UpdateCheck == nil {
+		cfg.UpdateCheck = defaults.UpdateCheck
+	} else {
+		if presence.UpdateCheck.Enabled == nil {
+			cfg.UpdateCheck.Enabled = defaults.UpdateCheck.Enabled
+		}
+		if presence.UpdateCheck.IntervalHours == nil || cfg.UpdateCheck.IntervalHours <= 0 {
+			cfg.UpdateCheck.IntervalHours = defaults.UpdateCheck.IntervalHours
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -32,6 +32,13 @@ func TestDefault(t *testing.T) {
 	if cfg.ContextWindow != 1000 {
 		t.Errorf("Expected ContextWindow 1000, got %d", cfg.ContextWindow)
 	}
+
+	if !cfg.UpdateCheck.Enabled {
+		t.Error("Expected update check enabled by default")
+	}
+	if cfg.UpdateCheck.IntervalHours != 24 {
+		t.Errorf("Expected update check interval 24h, got %d", cfg.UpdateCheck.IntervalHours)
+	}
 }
 
 func TestLoad_CreateDefault(t *testing.T) {
@@ -349,4 +356,15 @@ func TestGetConfigPath(t *testing.T) {
 
 func contains(s, substr string) bool {
 	return filepath.Base(filepath.Dir(s)) == ".wtf_cli" || filepath.Dir(s) == ".wtf_cli"
+}
+
+func TestValidate_InvalidUpdateCheckInterval(t *testing.T) {
+	cfg := Default()
+	cfg.OpenRouter.APIKey = "test"
+	cfg.UpdateCheck.IntervalHours = 0
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Expected error for non-positive update_check.interval_hours, got nil")
+	}
 }

--- a/pkg/ui/components/welcome/welcome.go
+++ b/pkg/ui/components/welcome/welcome.go
@@ -11,10 +11,22 @@ import (
 	"github.com/mattn/go-runewidth"
 )
 
-// WelcomeMessage returns the welcome box string to print to PTY
-func WelcomeMessage() string {
-	const boxWidth = 53 // Total inner width
+const boxWidth = 53 // Total inner width
 
+type UpdateNotice struct {
+	CurrentVersion string
+	LatestVersion  string
+	ReleaseURL     string
+	UpgradeCommand string
+}
+
+// WelcomeMessage returns the welcome box string to print to PTY.
+func WelcomeMessage() string {
+	return WelcomeMessageWithUpdate(nil)
+}
+
+// WelcomeMessageWithUpdate renders the welcome box and optional update details.
+func WelcomeMessageWithUpdate(update *UpdateNotice) string {
 	// Helper: create a line with content padded to boxWidth
 	makeLine := func(content string, visualWidth int) string {
 		pad := boxWidth - visualWidth
@@ -61,6 +73,30 @@ func WelcomeMessage() string {
 		lines = append(lines, makeLine(line, lineWidth))
 	}
 
+	if update != nil {
+		lines = append(lines, empty)
+		updateHeader := "  Update available:"
+		lines = append(lines, makeLine(styles.WelcomeHeaderStyle.Render(updateHeader), runewidth.StringWidth(updateHeader)))
+
+		cur := withFallback(strings.TrimSpace(update.CurrentVersion), version.Summary())
+		latest := withFallback(strings.TrimSpace(update.LatestVersion), "unknown")
+
+		updateLines := []string{
+			"    Current: " + cur,
+			"    Latest:  " + latest,
+			"    Releases: " + withFallback(strings.TrimSpace(update.ReleaseURL), "https://github.com/pakru/wtf_cli/releases"),
+			"    Upgrade:  " + withFallback(strings.TrimSpace(update.UpgradeCommand), "curl -fsSL https://raw.githubusercontent.com/pakru/wtf_cli/main/install.sh | bash"),
+		}
+		for _, raw := range updateLines {
+			line := raw
+			if runewidth.StringWidth(line) > boxWidth {
+				line = utils.TruncateToWidth(line, boxWidth)
+			}
+			lineWidth := runewidth.StringWidth(line)
+			lines = append(lines, makeLine(styles.TextStyle.Render(line), lineWidth))
+		}
+	}
+
 	lines = append(lines, empty)
 
 	// Version at bottom (centered, dimmed)
@@ -77,4 +113,11 @@ func WelcomeMessage() string {
 	lines = append(lines, "")
 
 	return strings.Join(lines, "\n") + "\n"
+}
+
+func withFallback(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
 }

--- a/pkg/ui/components/welcome/welcome.go
+++ b/pkg/ui/components/welcome/welcome.go
@@ -22,11 +22,44 @@ type UpdateNotice struct {
 
 // WelcomeMessage returns the welcome box string to print to PTY.
 func WelcomeMessage() string {
-	return WelcomeMessageWithUpdate(nil)
+	return buildWelcomeBox()
 }
 
-// WelcomeMessageWithUpdate renders the welcome box and optional update details.
+// WelcomeMessageWithUpdate renders the welcome box.
+// The update section is now rendered separately via UpdateBanner.
+// This function is kept for backward compatibility.
 func WelcomeMessageWithUpdate(update *UpdateNotice) string {
+	return buildWelcomeBox()
+}
+
+// UpdateBanner renders a compact, box-free update notification.
+// URLs and commands render at full terminal width — never truncated.
+func UpdateBanner(notice *UpdateNotice) string {
+	if notice == nil {
+		return ""
+	}
+
+	cur := withFallback(strings.TrimSpace(notice.CurrentVersion), version.Summary())
+	latest := withFallback(strings.TrimSpace(notice.LatestVersion), "unknown")
+	releaseURL := withFallback(strings.TrimSpace(notice.ReleaseURL), "https://github.com/pakru/wtf_cli/releases")
+	upgradeCmd := withFallback(strings.TrimSpace(notice.UpgradeCommand), "curl -fsSL https://raw.githubusercontent.com/pakru/wtf_cli/main/install.sh | bash")
+
+	// Header: 🆕 Update available: v0.4.14 → v0.4.15
+	header := styles.WelcomeHeaderStyle.Render("  🆕 Update available: ") +
+		styles.WelcomeVersionStyle.Render(cur) +
+		styles.WelcomeHeaderStyle.Render(" → ") +
+		styles.WelcomeUpdateVersionStyle.Render(latest)
+
+	// URL line (blue, underlined, full width)
+	urlLine := "     " + styles.WelcomeHeaderStyle.Render("Releases: ") + styles.WelcomeURLStyle.Render(releaseURL)
+
+	// Command line (green, bold, full width)
+	cmdLine := "     " + styles.WelcomeHeaderStyle.Render("Upgrade:  ") + styles.WelcomeCommandStyle.Render(upgradeCmd)
+
+	return "\n" + header + "\n" + urlLine + "\n" + cmdLine + "\n\n"
+}
+
+func buildWelcomeBox() string {
 	// Helper: create a line with content padded to boxWidth
 	makeLine := func(content string, visualWidth int) string {
 		pad := boxWidth - visualWidth
@@ -71,30 +104,6 @@ func WelcomeMessageWithUpdate(update *UpdateNotice) string {
 		line := styles.WelcomeKeyStyle.Render(keyFormatted) + styles.TextStyle.Render(s.desc)
 		lineWidth := runewidth.StringWidth(keyFormatted) + runewidth.StringWidth(s.desc)
 		lines = append(lines, makeLine(line, lineWidth))
-	}
-
-	if update != nil {
-		lines = append(lines, empty)
-		updateHeader := "  Update available:"
-		lines = append(lines, makeLine(styles.WelcomeHeaderStyle.Render(updateHeader), runewidth.StringWidth(updateHeader)))
-
-		cur := withFallback(strings.TrimSpace(update.CurrentVersion), version.Summary())
-		latest := withFallback(strings.TrimSpace(update.LatestVersion), "unknown")
-
-		updateLines := []string{
-			"    Current: " + cur,
-			"    Latest:  " + latest,
-			"    Releases: " + withFallback(strings.TrimSpace(update.ReleaseURL), "https://github.com/pakru/wtf_cli/releases"),
-			"    Upgrade:  " + withFallback(strings.TrimSpace(update.UpgradeCommand), "curl -fsSL https://raw.githubusercontent.com/pakru/wtf_cli/main/install.sh | bash"),
-		}
-		for _, raw := range updateLines {
-			line := raw
-			if runewidth.StringWidth(line) > boxWidth {
-				line = utils.TruncateToWidth(line, boxWidth)
-			}
-			lineWidth := runewidth.StringWidth(line)
-			lines = append(lines, makeLine(styles.TextStyle.Render(line), lineWidth))
-		}
 	}
 
 	lines = append(lines, empty)

--- a/pkg/ui/components/welcome/welcome_test.go
+++ b/pkg/ui/components/welcome/welcome_test.go
@@ -35,3 +35,26 @@ func TestWelcomeMessage_ContainsBorder(t *testing.T) {
 		t.Error("Expected welcome message to contain box border characters")
 	}
 }
+
+func TestWelcomeMessageWithUpdate_ContainsUpdateInfo(t *testing.T) {
+	msg := WelcomeMessageWithUpdate(&UpdateNotice{
+		CurrentVersion: "v0.1.0",
+		LatestVersion:  "v0.2.0",
+		ReleaseURL:     "https://github.com/pakru/wtf_cli/releases",
+		UpgradeCommand: "curl -fsSL https://raw.githubusercontent.com/pakru/wtf_cli/main/install.sh | bash",
+	})
+
+	checks := []string{"Update available:", "Current: v0.1.0", "Latest:  v0.2.0", "Releases:", "Upgrade:"}
+	for _, check := range checks {
+		if !strings.Contains(msg, check) {
+			t.Fatalf("Expected welcome update message to contain %q", check)
+		}
+	}
+}
+
+func TestWelcomeMessage_NoUpdateSectionByDefault(t *testing.T) {
+	msg := WelcomeMessage()
+	if strings.Contains(msg, "Update available:") {
+		t.Fatal("Expected default welcome message to not contain update section")
+	}
+}

--- a/pkg/ui/components/welcome/welcome_test.go
+++ b/pkg/ui/components/welcome/welcome_test.go
@@ -1,9 +1,16 @@
 package welcome
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 )
+
+var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string {
+	return ansiRegex.ReplaceAllString(s, "")
+}
 
 func TestWelcomeMessage_ContainsShortcuts(t *testing.T) {
 	msg := WelcomeMessage()
@@ -36,25 +43,84 @@ func TestWelcomeMessage_ContainsBorder(t *testing.T) {
 	}
 }
 
-func TestWelcomeMessageWithUpdate_ContainsUpdateInfo(t *testing.T) {
+func TestWelcomeMessage_NoUpdateSectionByDefault(t *testing.T) {
+	msg := WelcomeMessage()
+	if strings.Contains(msg, "Update available") {
+		t.Fatal("Expected default welcome message to not contain update section")
+	}
+}
+
+func TestWelcomeMessageWithUpdate_DoesNotContainUpdateSection(t *testing.T) {
+	// WelcomeMessageWithUpdate now delegates to buildWelcomeBox (no update info).
+	// Update info is rendered separately by UpdateBanner.
 	msg := WelcomeMessageWithUpdate(&UpdateNotice{
 		CurrentVersion: "v0.1.0",
 		LatestVersion:  "v0.2.0",
 		ReleaseURL:     "https://github.com/pakru/wtf_cli/releases",
-		UpgradeCommand: "curl -fsSL https://raw.githubusercontent.com/pakru/wtf_cli/main/install.sh | bash",
+		UpgradeCommand: "curl -fsSL https://example.com/install.sh | bash",
+	})
+	if strings.Contains(msg, "Update available") {
+		t.Fatal("WelcomeMessageWithUpdate should no longer embed update info in the welcome box")
+	}
+}
+
+func TestUpdateBanner_ContainsVersionInfo(t *testing.T) {
+	banner := UpdateBanner(&UpdateNotice{
+		CurrentVersion: "v0.1.0",
+		LatestVersion:  "v0.2.0",
+		ReleaseURL:     "https://github.com/pakru/wtf_cli/releases",
+		UpgradeCommand: "curl -fsSL https://example.com/install.sh | bash",
 	})
 
-	checks := []string{"Update available:", "Current: v0.1.0", "Latest:  v0.2.0", "Releases:", "Upgrade:"}
+	checks := []string{
+		"Update available",
+		"v0.1.0",
+		"v0.2.0",
+		"→",
+	}
+	plain := stripANSI(banner)
 	for _, check := range checks {
-		if !strings.Contains(msg, check) {
-			t.Fatalf("Expected welcome update message to contain %q", check)
+		if !strings.Contains(plain, check) {
+			t.Errorf("Expected update banner to contain %q", check)
 		}
 	}
 }
 
-func TestWelcomeMessage_NoUpdateSectionByDefault(t *testing.T) {
-	msg := WelcomeMessage()
-	if strings.Contains(msg, "Update available:") {
-		t.Fatal("Expected default welcome message to not contain update section")
+func TestUpdateBanner_ContainsFullURL(t *testing.T) {
+	fullURL := "https://github.com/pakru/wtf_cli/releases"
+	banner := UpdateBanner(&UpdateNotice{
+		CurrentVersion: "v0.1.0",
+		LatestVersion:  "v0.2.0",
+		ReleaseURL:     fullURL,
+		UpgradeCommand: "curl -fsSL https://example.com/install.sh | bash",
+	})
+
+	// The URL should NOT be truncated (strip ANSI since underline wraps each char)
+	plain := stripANSI(banner)
+	if !strings.Contains(plain, fullURL) {
+		t.Fatalf("Expected update banner to contain full URL %q, got:\n%s", fullURL, plain)
+	}
+}
+
+func TestUpdateBanner_ContainsFullCommand(t *testing.T) {
+	fullCmd := "curl -fsSL https://raw.githubusercontent.com/pakru/wtf_cli/main/install.sh | bash"
+	banner := UpdateBanner(&UpdateNotice{
+		CurrentVersion: "v0.1.0",
+		LatestVersion:  "v0.2.0",
+		ReleaseURL:     "https://github.com/pakru/wtf_cli/releases",
+		UpgradeCommand: fullCmd,
+	})
+
+	// The command should NOT be truncated (strip ANSI for bold-styled text)
+	plain := stripANSI(banner)
+	if !strings.Contains(plain, fullCmd) {
+		t.Fatalf("Expected update banner to contain full command %q, got:\n%s", fullCmd, plain)
+	}
+}
+
+func TestUpdateBanner_NilReturnsEmpty(t *testing.T) {
+	banner := UpdateBanner(nil)
+	if banner != "" {
+		t.Fatalf("Expected empty string for nil notice, got: %q", banner)
 	}
 }

--- a/pkg/ui/model.go
+++ b/pkg/ui/model.go
@@ -1018,12 +1018,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			ReleaseURL:     msg.Result.ReleaseURL,
 			UpgradeCommand: msg.Result.UpgradeCommand,
 		}
-		if !m.startupPTYOutputSeen {
-			m.viewport.Clear()
-			m.viewport.AppendOutput([]byte(welcome.WelcomeMessageWithUpdate(notice)))
-		} else {
-			m.viewport.AppendOutput([]byte("\n" + welcome.WelcomeMessageWithUpdate(notice)))
-		}
+		m.viewport.AppendOutput([]byte(welcome.UpdateBanner(notice)))
 		m.startupUpdateShown = true
 		slog.Info("update_check_success", "current", msg.Result.CurrentVersion, "latest", msg.Result.LatestVersion, "update_available", true)
 		return m, nil

--- a/pkg/ui/model.go
+++ b/pkg/ui/model.go
@@ -28,6 +28,8 @@ import (
 	"wtf_cli/pkg/ui/input"
 	"wtf_cli/pkg/ui/render"
 	"wtf_cli/pkg/ui/terminal"
+	"wtf_cli/pkg/updatecheck"
+	"wtf_cli/pkg/version"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -103,6 +105,9 @@ type Model struct {
 	fullScreenMode  bool
 	fullScreenPanel *fullscreen.FullScreenPanel
 	altScreenState  *terminal.AltScreenState
+
+	startupPTYOutputSeen bool
+	startupUpdateShown   bool
 }
 
 // NewModel creates a new Bubble Tea model
@@ -158,6 +163,7 @@ func (m Model) Init() tea.Cmd {
 		listenToPTY(m.ptyFile), // Start listening to PTY output
 		tickDirectory(),        // Start directory update ticker
 		resolveGitBranchCmd(m.currentDir, m.gitBranchResolver),
+		fetchUpdateCheckCmd(),
 	)
 }
 
@@ -993,11 +999,44 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case updateCheckMsg:
+		if msg.SkipReason != "" {
+			slog.Info("update_check_skipped", "reason", msg.SkipReason)
+			return m, nil
+		}
+		if msg.Err != nil {
+			slog.Warn("update_check_error", "error", msg.Err)
+			return m, nil
+		}
+		if !msg.Result.UpdateAvailable || m.startupUpdateShown {
+			return m, nil
+		}
+
+		notice := &welcome.UpdateNotice{
+			CurrentVersion: msg.Result.CurrentVersion,
+			LatestVersion:  msg.Result.LatestVersion,
+			ReleaseURL:     msg.Result.ReleaseURL,
+			UpgradeCommand: msg.Result.UpgradeCommand,
+		}
+		if !m.startupPTYOutputSeen {
+			m.viewport.Clear()
+			m.viewport.AppendOutput([]byte(welcome.WelcomeMessageWithUpdate(notice)))
+		} else {
+			m.viewport.AppendOutput([]byte("\n" + welcome.WelcomeMessageWithUpdate(notice)))
+		}
+		m.startupUpdateShown = true
+		slog.Info("update_check_success", "current", msg.Result.CurrentVersion, "latest", msg.Result.LatestVersion, "update_available", true)
+		return m, nil
+
 	case ptyOutputMsg:
 		// Suppress PTY output briefly after resize to prevent prompt reprint from showing
 		if !m.resizeTime.IsZero() && time.Since(m.resizeTime) < 100*time.Millisecond {
 			// Skip appending to viewport but still schedule next read
 			return m, listenToPTY(m.ptyFile)
+		}
+
+		if len(msg.data) > 0 {
+			m.startupPTYOutputSeen = true
 		}
 
 		// Append to batch buffer
@@ -1672,6 +1711,46 @@ func applyPasteToOverlay(content string, update func(tea.KeyPressMsg) tea.Cmd) t
 		return cmds[0]
 	}
 	return tea.Batch(cmds...)
+}
+
+type updateCheckMsg struct {
+	Result     updatecheck.Result
+	Err        error
+	SkipReason string
+}
+
+func fetchUpdateCheckCmd() tea.Cmd {
+	return func() tea.Msg {
+		cfg, err := config.Load(config.GetConfigPath())
+		if err != nil {
+			return updateCheckMsg{SkipReason: "config_error"}
+		}
+		if !cfg.UpdateCheck.Enabled {
+			return updateCheckMsg{SkipReason: "disabled"}
+		}
+
+		current := strings.TrimSpace(version.Version)
+		if current == "" || strings.EqualFold(current, "dev") {
+			return updateCheckMsg{SkipReason: "dev_build"}
+		}
+
+		slog.Info("update_check_start")
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		result, err := updatecheck.CheckLatest(ctx, current, updatecheck.CheckOptions{
+			Interval: time.Duration(cfg.UpdateCheck.IntervalHours) * time.Hour,
+		})
+		if err != nil {
+			return updateCheckMsg{Err: err}
+		}
+
+		if !result.UpdateAvailable {
+			slog.Info("update_check_success", "current", result.CurrentVersion, "latest", result.LatestVersion, "update_available", false)
+		}
+
+		return updateCheckMsg{Result: result}
+	}
 }
 
 // Copilot auth status message type.

--- a/pkg/ui/model_test.go
+++ b/pkg/ui/model_test.go
@@ -22,6 +22,7 @@ import (
 	"wtf_cli/pkg/ui/components/sidebar"
 	"wtf_cli/pkg/ui/components/testutils"
 	"wtf_cli/pkg/ui/input"
+	"wtf_cli/pkg/updatecheck"
 
 	tea "charm.land/bubbletea/v2"
 )
@@ -1240,5 +1241,47 @@ func TestGetModelForProvider_Google(t *testing.T) {
 	cfg.Providers.Google.Model = ""
 	if got := getModelForProvider(cfg); got != "gemini-3-flash-preview" {
 		t.Fatalf("Expected Google fallback model, got %q", got)
+	}
+}
+
+func TestModel_Update_UpdateCheckMsg_ShowsWelcomeUpdate(t *testing.T) {
+	m := NewModel(nil, buffer.New(100), capture.NewSessionContext(), nil)
+	m.ready = true
+	m.viewport.SetSize(80, 24)
+
+	res := updatecheck.Result{
+		CurrentVersion:  "v0.1.0",
+		LatestVersion:   "v0.2.0",
+		ReleaseURL:      "https://github.com/pakru/wtf_cli/releases",
+		UpgradeCommand:  "curl -fsSL https://raw.githubusercontent.com/pakru/wtf_cli/main/install.sh | bash",
+		UpdateAvailable: true,
+	}
+
+	newModel, _ := m.Update(updateCheckMsg{Result: res})
+	updated := newModel.(Model)
+
+	if !updated.startupUpdateShown {
+		t.Fatal("expected startup update notice to be shown")
+	}
+	content := updated.viewport.GetContent()
+	if !strings.Contains(content, "Update available:") {
+		t.Fatalf("expected viewport content to include update section, got %q", content)
+	}
+}
+
+func TestModel_Update_UpdateCheckMsg_ErrorNoUserNotice(t *testing.T) {
+	m := NewModel(nil, buffer.New(100), capture.NewSessionContext(), nil)
+	m.ready = true
+	m.viewport.SetSize(80, 24)
+	original := m.viewport.GetContent()
+
+	newModel, _ := m.Update(updateCheckMsg{Err: fmt.Errorf("network down")})
+	updated := newModel.(Model)
+
+	if updated.startupUpdateShown {
+		t.Fatal("expected no startup update shown on error")
+	}
+	if updated.viewport.GetContent() != original {
+		t.Fatal("expected viewport to remain unchanged on update-check error")
 	}
 }

--- a/pkg/ui/styles/theme.go
+++ b/pkg/ui/styles/theme.go
@@ -188,6 +188,21 @@ var (
 	// WelcomeVersionStyle for version info (dimmed)
 	WelcomeVersionStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("244"))
+
+	// WelcomeURLStyle for clickable URLs (blue + underline = universal "link" signal)
+	WelcomeURLStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("111")).
+			Underline(true)
+
+	// WelcomeCommandStyle for copy-paste shell commands
+	WelcomeCommandStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("156")).
+				Bold(true)
+
+	// WelcomeUpdateVersionStyle for the new version number (green = success)
+	WelcomeUpdateVersionStyle = lipgloss.NewStyle().
+					Foreground(lipgloss.Color("114")).
+					Bold(true)
 )
 
 // Full-screen panel styles

--- a/pkg/updatecheck/updatecheck.go
+++ b/pkg/updatecheck/updatecheck.go
@@ -1,0 +1,208 @@
+package updatecheck
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultLatestReleaseURL = "https://api.github.com/repos/pakru/wtf_cli/releases/latest"
+	releasePageURL          = "https://github.com/pakru/wtf_cli/releases"
+	upgradeCommand          = "curl -fsSL https://raw.githubusercontent.com/pakru/wtf_cli/main/install.sh | bash"
+)
+
+type Result struct {
+	CurrentVersion  string
+	LatestVersion   string
+	ReleaseURL      string
+	UpgradeCommand  string
+	UpdateAvailable bool
+}
+
+type CheckOptions struct {
+	LatestReleaseURL string
+	CachePath        string
+	Interval         time.Duration
+	HTTPClient       *http.Client
+	Now              func() time.Time
+}
+
+type latestReleaseResponse struct {
+	TagName string `json:"tag_name"`
+}
+
+type cacheState struct {
+	LastChecked   time.Time `json:"last_checked"`
+	LatestVersion string    `json:"latest_version"`
+}
+
+func DefaultCachePath() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(homeDir) == "" {
+		return filepath.Join(".wtf_cli", "update_check_cache.json")
+	}
+	return filepath.Join(homeDir, ".wtf_cli", "update_check_cache.json")
+}
+
+func CheckLatest(ctx context.Context, currentVersion string, opts CheckOptions) (Result, error) {
+	result := Result{
+		CurrentVersion: strings.TrimSpace(currentVersion),
+		ReleaseURL:     releasePageURL,
+		UpgradeCommand: upgradeCommand,
+	}
+	current, ok := normalizeVersion(result.CurrentVersion)
+	if !ok || current == "dev" {
+		return result, nil
+	}
+
+	cachePath := strings.TrimSpace(opts.CachePath)
+	if cachePath == "" {
+		cachePath = DefaultCachePath()
+	}
+	interval := opts.Interval
+	if interval <= 0 {
+		interval = 24 * time.Hour
+	}
+	nowFn := opts.Now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+
+	if cached, ok := readCache(cachePath); ok && nowFn().Sub(cached.LastChecked) < interval {
+		result.LatestVersion = cached.LatestVersion
+		latest, parsed := normalizeVersion(cached.LatestVersion)
+		if parsed {
+			result.UpdateAvailable = compareVersions(current, latest) < 0
+		}
+		return result, nil
+	}
+
+	latest, err := fetchLatestVersion(ctx, opts)
+	if err != nil {
+		return result, err
+	}
+	result.LatestVersion = latest
+
+	normalizedLatest, ok := normalizeVersion(latest)
+	if !ok {
+		return result, fmt.Errorf("invalid latest release version: %q", latest)
+	}
+	result.UpdateAvailable = compareVersions(current, normalizedLatest) < 0
+
+	_ = writeCache(cachePath, cacheState{LastChecked: nowFn(), LatestVersion: latest})
+
+	return result, nil
+}
+
+func fetchLatestVersion(ctx context.Context, opts CheckOptions) (string, error) {
+	url := strings.TrimSpace(opts.LatestReleaseURL)
+	if url == "" {
+		url = defaultLatestReleaseURL
+	}
+
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request latest release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("latest release status: %d", resp.StatusCode)
+	}
+
+	var payload latestReleaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decode latest release payload: %w", err)
+	}
+	if strings.TrimSpace(payload.TagName) == "" {
+		return "", errors.New("empty tag_name in latest release payload")
+	}
+
+	return strings.TrimSpace(payload.TagName), nil
+}
+
+func normalizeVersion(input string) (string, bool) {
+	v := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(input), "v"))
+	if v == "" {
+		return "", false
+	}
+	if strings.EqualFold(v, "dev") {
+		return "dev", true
+	}
+
+	base := strings.SplitN(v, "-", 2)[0]
+	parts := strings.Split(base, ".")
+	if len(parts) == 0 || len(parts) > 3 {
+		return "", false
+	}
+	for len(parts) < 3 {
+		parts = append(parts, "0")
+	}
+	for _, p := range parts {
+		if _, err := strconv.Atoi(p); err != nil {
+			return "", false
+		}
+	}
+	return strings.Join(parts, "."), true
+}
+
+func compareVersions(current, latest string) int {
+	curParts := strings.Split(current, ".")
+	latestParts := strings.Split(latest, ".")
+	for i := range 3 {
+		curN, _ := strconv.Atoi(curParts[i])
+		latestN, _ := strconv.Atoi(latestParts[i])
+		if curN < latestN {
+			return -1
+		}
+		if curN > latestN {
+			return 1
+		}
+	}
+	return 0
+}
+
+func readCache(path string) (cacheState, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cacheState{}, false
+	}
+	var cache cacheState
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return cacheState{}, false
+	}
+	if cache.LastChecked.IsZero() || strings.TrimSpace(cache.LatestVersion) == "" {
+		return cacheState{}, false
+	}
+	return cache, true
+}
+
+func writeCache(path string, cache cacheState) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}

--- a/pkg/updatecheck/updatecheck_test.go
+++ b/pkg/updatecheck/updatecheck_test.go
@@ -1,0 +1,108 @@
+package updatecheck
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		in   string
+		out  string
+		good bool
+	}{
+		{in: "v1.2.3", out: "1.2.3", good: true},
+		{in: "1.2", out: "1.2.0", good: true},
+		{in: " v0.9.1 ", out: "0.9.1", good: true},
+		{in: "v2.0.0-beta.1", out: "2.0.0", good: true},
+		{in: "dev", out: "dev", good: true},
+		{in: "", out: "", good: false},
+		{in: "abc", out: "", good: false},
+	}
+
+	for _, tt := range tests {
+		got, ok := normalizeVersion(tt.in)
+		if ok != tt.good || got != tt.out {
+			t.Fatalf("normalizeVersion(%q) = (%q,%v), expected (%q,%v)", tt.in, got, ok, tt.out, tt.good)
+		}
+	}
+}
+
+func TestCheckLatest_FetchesAndCaches(t *testing.T) {
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"tag_name":"v1.4.0"}`))
+	}))
+	defer srv.Close()
+
+	tmpDir := t.TempDir()
+	cachePath := filepath.Join(tmpDir, "cache.json")
+	now := time.Now()
+	opts := CheckOptions{
+		LatestReleaseURL: srv.URL,
+		CachePath:        cachePath,
+		Interval:         24 * time.Hour,
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	result, err := CheckLatest(context.Background(), "v1.3.0", opts)
+	if err != nil {
+		t.Fatalf("CheckLatest() error = %v", err)
+	}
+	if !result.UpdateAvailable {
+		t.Fatalf("expected update available")
+	}
+	if hits != 1 {
+		t.Fatalf("expected 1 HTTP call, got %d", hits)
+	}
+
+	result2, err := CheckLatest(context.Background(), "v1.3.0", opts)
+	if err != nil {
+		t.Fatalf("CheckLatest() cached error = %v", err)
+	}
+	if !result2.UpdateAvailable {
+		t.Fatalf("expected update available from cache")
+	}
+	if hits != 1 {
+		t.Fatalf("expected cached run to skip HTTP call; hits=%d", hits)
+	}
+}
+
+func TestCheckLatest_DevVersionSkips(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"tag_name":"v9.9.9"}`))
+	}))
+	defer srv.Close()
+
+	_, err := CheckLatest(context.Background(), "dev", CheckOptions{LatestReleaseURL: srv.URL})
+	if err != nil {
+		t.Fatalf("expected nil error for dev version, got %v", err)
+	}
+	if called {
+		t.Fatalf("expected no network call for dev version")
+	}
+}
+
+func TestCheckLatest_InvalidPayload(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"tag_name":""}`))
+	}))
+	defer srv.Close()
+
+	_, err := CheckLatest(context.Background(), "1.0.0", CheckOptions{LatestReleaseURL: srv.URL, CachePath: filepath.Join(t.TempDir(), "cache.json")})
+	if err == nil {
+		t.Fatalf("expected error for invalid payload")
+	}
+}


### PR DESCRIPTION
### Motivation
- Inform users when a newer `wtf_cli` release is available without blocking startup or introducing failures.
- Provide configurable caching and interval to avoid repeated network calls and allow opt-out.
- Surface the update information in the welcome box under shortcuts with a one-line upgrade command and release link.

### Description
- Add new package `pkg/updatecheck` implementing `CheckLatest(ctx, currentVersion, opts)` with caching, GitHub latest-release fetch, version normalization/compare, and `DefaultCachePath()`; includes `CheckOptions` and `Result` types.
- Extend config with `UpdateCheckConfig` and new `update_check` JSON block, defaulting to `enabled: true` and `interval_hours: 24`, plus validation and default application in `pkg/config/config.go` and updated tests.
- Integrate async update check into the TUI model by adding `fetchUpdateCheckCmd()` and `updateCheckMsg` which run at startup (non-blocking) and log structured events; the model appends the update notice to the viewport when an update is available.
- Extend welcome renderer with `WelcomeMessageWithUpdate(*UpdateNotice)` and `UpdateNotice` struct to render current/latest version, releases URL, and upgrade command under the shortcuts; preserve original `WelcomeMessage()` behavior and add truncation/fallback handling.
- Add unit tests for `pkg/updatecheck` (`normalizeVersion`, caching, dev-skip, invalid payload), welcome rendering tests, config default/validation tests, and model tests to ensure the update message is applied or suppressed on error.

### Testing
- Ran `go test ./pkg/updatecheck` which executes `TestNormalizeVersion`, `TestCheckLatest_FetchesAndCaches`, `TestCheckLatest_DevVersionSkips`, and `TestCheckLatest_InvalidPayload`, and all tests passed.
- Ran `go test ./pkg/config` which covers `TestDefault`, `TestLoad_*` and `TestValidate_InvalidUpdateCheckInterval`, and they passed.
- Ran `go test ./pkg/ui/...` which includes welcome and model tests (`TestWelcomeMessageWithUpdate_ContainsUpdateInfo`, `TestWelcomeMessage_NoUpdateSectionByDefault`, `TestModel_Update_UpdateCheckMsg_*`) and they passed.
- Performed full test sweep with `go test ./...` and `make check` (project checks), and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa0d7109388329abbcd1efeb9c7e61)